### PR TITLE
Remove completed TODO comment

### DIFF
--- a/implementation.js
+++ b/implementation.js
@@ -5,7 +5,7 @@ var OrdinaryObjectCreate = require('es-abstract/2024/OrdinaryObjectCreate');
 
 var forEach = require('es-abstract/helpers/forEach');
 
-var GroupBy = require('es-abstract/2024/GroupBy'); // TODO: replace with es-abstract 2024 implementation
+var GroupBy = require('es-abstract/2024/GroupBy');
 
 module.exports = function groupBy(items, callbackfn) {
 	var groups = GroupBy(items, callbackfn, 'PROPERTY'); // step 1


### PR DESCRIPTION
**Description:**
Remove a TODO comment that looks as if it has been addressed in [this commit](https://github.com/es-shims/Object.groupBy/commit/f1d3e701aff0a36e4d7373059812a9b978c7ad7f#diff-e7cc9272a32095277b776aa1a985717480a5fe273957f79045afaf39967eed93R8)